### PR TITLE
Wrapped June's stream notes list in ul like other months

### DIFF
--- a/public-site/src/pages/stream-notes.js
+++ b/public-site/src/pages/stream-notes.js
@@ -9,11 +9,13 @@ const StreamNotes = ({ data }) => {
       <h1>Stream Notes Page!!</h1>
       <h2>June</h2>
       <p>{data.JuneStreamNotes.edges.length} Streams notes!</p>
-      {data.JuneStreamNotes.edges.map(({ node }) => (
-        <li key={node.id}>
-          <Link to={node.fields.slug}>{node.headings[0].value}</Link>
-        </li>
-      ))}
+      <ul>
+        {data.JuneStreamNotes.edges.map(({ node }) => (
+          <li key={node.id}>
+            <Link to={node.fields.slug}>{node.headings[0].value}</Link>
+          </li>
+        ))}
+      </ul>
 
       <hr />
       <h2>May</h2>


### PR DESCRIPTION
The rest of the months' lists were wrapped with a `<ul>` except June. Added the ul to make them all aligned. 