### PR TITLE
Better aligning items in desktop navbar

### DIFF
--- a/public-site/src/components/Navigation.js
+++ b/public-site/src/components/Navigation.js
@@ -76,7 +76,7 @@ const StyledNav = styled.nav`
       flex-direction: row;
       justify-content: space-between;
       margin: 0 auto;
-      padding: 0 1.0875rem;
+      padding: 0.5rem 1.0875rem;
       li {
         display: block;
         padding: 0;

--- a/public-site/src/components/SiteHeader.js
+++ b/public-site/src/components/SiteHeader.js
@@ -6,7 +6,6 @@ import Navigation from "./Navigation"
 
 const StyledHeader = styled.header`
   background: rebeccapurple;
-  margin-bottom: 1rem;
   div {
     margin: 0 auto;
     max-width: 960px;

--- a/public-site/src/components/layout.js
+++ b/public-site/src/components/layout.js
@@ -17,6 +17,7 @@ import "./layout.css"
 const StyledContainer = styled.div`
   margin: 0 auto;
   max-width: 960px;
+  margin-top: 1rem;
   padding: 0px 1.0875rem 1.45rem;
   padding-top: 0;
 `


### PR DESCRIPTION
The navigation items were previously more sitting on the bottom bar of the navigation. I made some tweaks to the CSS to have the content placed in the center instead.

Here's a screenshot of before & after respectively:

![Screen Shot 2019-06-09 at 6 32 07 PM](https://user-images.githubusercontent.com/3685876/59165128-0fe01b80-8ae5-11e9-9ea6-850c3d67684c.png)
